### PR TITLE
Allow hyphens in hostnames.

### DIFF
--- a/consoles-computers/src/main/java/ca/jarcode/consoles/computer/filesystem/FSBlock.java
+++ b/consoles-computers/src/main/java/ca/jarcode/consoles/computer/filesystem/FSBlock.java
@@ -49,7 +49,7 @@ public abstract class FSBlock {
 		if (str.length() > 24) return false;
 		for (char c : str.toCharArray()) {
 			if (!((0x30 <= c && 0x39 >= c) || (0x41 <= c && 0x5A >= c)
-					|| (0x61 <= c && 0x7A >= c) || c == '.' || c == '$' || c == '_' || c == '(' || c == ')')) {
+					|| (0x61 <= c && 0x7A >= c) || c == '.' || c == '$' || c == '_' || c == '(' || c == ')' || c =='-')) {
 				return false;
 			}
 		}


### PR DESCRIPTION
JARCODE TRIGGERED ME BY NOT ALLOWING MY HOSTNAME TO BE A HYPHENATED RACE /s